### PR TITLE
Update metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,5 +1,5 @@
 # Encoding: utf-8
-name 'openstack_client'
+name 'openstack-client'
 maintainer 'openstack-chef'
 maintainer_email 'opscode-chef-openstack@googlegroups.com'
 license 'Apache2'


### PR DESCRIPTION
Getting a complaint when running chef exec rake berks_vendor

In your Berksfile, you have:

  cookbook 'openstack-client'

But that cookbook is actually named 'openstack_client'

This can cause potentially unwanted side-effects in the future.
